### PR TITLE
Implement http.Handler interface

### DIFF
--- a/00_A$AP Learn 🚀/07_Web Servers/01_Minimal Web Server/index.md
+++ b/00_A$AP Learn 🚀/07_Web Servers/01_Minimal Web Server/index.md
@@ -16,7 +16,7 @@ import (
 type miniHTTPServer struct {}
 
 // Fit the `http.Handler` interface by implementing the standard ServeHTTP method
-func (s *miniHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s miniHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
     // Send a string back to the requester
     w.Write([]byte("Mini HTTP server in Go!"))
 }


### PR DESCRIPTION
## Description
While having fun with this example and building my own simple server I got an error: 

`.\main.go:16:48: cannot use httpServer literal (type httpServer) as type http.Handler in argument to http.ListenAndServe:
        httpServer does not implement http.Handler (ServeHTTP method has pointer receiver)`.  

Could you please check if my fix is right? After this change everything seems to work correctly!